### PR TITLE
Improve alt text for images

### DIFF
--- a/src/app/(blog)/blog/[slug]/page.tsx
+++ b/src/app/(blog)/blog/[slug]/page.tsx
@@ -163,7 +163,8 @@ export default async function BlogPostPage({
                         <div className="relative aspect-video rounded-xl overflow-hidden border border-gray-800 mb-8 bg-black">
                             <Image
                                 src={mainImageUrl}
-                                alt={data.title || "Article hero"}
+                                alt={data.mainImage?.alt || data.title || ''}
+                                role={data.mainImage?.alt || data.title ? undefined : 'presentation'}
                                 fill
                                 className="object-contain"
                                 sizes="(max-width: 1024px) 100vw, 960px"
@@ -203,7 +204,7 @@ export default async function BlogPostPage({
                                         <Link href={`/blog/${rp.slug}`} className="group" key={rp.slug}>
                                             <div className="space-y-3">
                                                 <div className="relative h-48 rounded-lg overflow-hidden border border-gray-800 group-hover:border-purple-500/50 transition-colors">
-                                                    <Image src={img} alt={`${rp.title} thumbnail`} fill className="object-cover" />
+                                                    <Image src={img} alt={rp.mainImage?.alt || rp.title} fill className="object-cover" />
                                                 </div>
                                                 <div>
                                                     {rp.category?.title && (

--- a/src/app/topics/[slug]/page.tsx
+++ b/src/app/topics/[slug]/page.tsx
@@ -188,7 +188,7 @@ function ArticleCard({
                 <div className="relative h-52 sm:h-56 md:h-64 xl:h-72 rounded-lg overflow-hidden border border-gray-800 group-hover:border-purple-500/50 transition-colors">
                     <Image
                         src={imageUrl}
-                        alt={`${title} thumbnail`}
+                        alt={title}
                         fill
                         className="object-cover"
                         sizes="(max-width: 640px) 100vw, (max-width: 1280px) 50vw, 33vw"

--- a/src/components/PortableBody.tsx
+++ b/src/components/PortableBody.tsx
@@ -11,7 +11,16 @@ const components: PortableTextComponents = {
             const blur = value?.asset?.metadata?.lqip
             return (
                 <figure className="my-6">
-                    <Image src={url} alt={value?.alt || ''} width={1200} height={675} className="rounded-xl" placeholder={blur ? 'blur' : 'empty'} blurDataURL={blur} />
+                    <Image
+                        src={url}
+                        alt={value?.alt || ''}
+                        role={value?.alt ? undefined : 'presentation'}
+                        width={1200}
+                        height={675}
+                        className="rounded-xl"
+                        placeholder={blur ? 'blur' : 'empty'}
+                        blurDataURL={blur}
+                    />
                     {value?.alt && <figcaption className="mt-2 text-sm text-gray-500">{value.alt}</figcaption>}
                 </figure>
             )

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -93,7 +93,8 @@ export default function Hero({ post }: { post: HeroType | null }) {
                             <>
                                 <Image
                                     src={heroImg}
-                                    alt={post?.title || "Featured post"}
+                                    alt={post?.mainImage?.alt || post?.title || ''}
+                                    role={post?.mainImage?.alt || post?.title ? undefined : 'presentation'}
                                     fill
                                     priority
                                     sizes="(max-width: 1024px) 100vw, 50vw"

--- a/src/components/post/ArticleCard.tsx
+++ b/src/components/post/ArticleCard.tsx
@@ -17,7 +17,13 @@ export default function ArticleCard({ post }: { post: PostCardType }) {
         <Link href={`/blog/${post.slug}`} className="group">
             <div className="space-y-3">
                 <div className="relative h-72 rounded-lg overflow-hidden border border-gray-800 group-hover:border-purple-500/50 transition-colors">
-                    <Image src={image} alt={`${post.title} thumbnail`} fill className="object-cover" sizes="(max-width: 768px) 100vw, 33vw" />
+                    <Image
+                        src={image}
+                        alt={post.mainImage?.alt || post.title}
+                        fill
+                        className="object-cover"
+                        sizes="(max-width: 768px) 100vw, 33vw"
+                    />
                 </div>
                 <div>
                     <div className="flex items-center gap-2 text-xs text-purple-500 mb-2">

--- a/src/components/post/ArticlelCard.tsx
+++ b/src/components/post/ArticlelCard.tsx
@@ -31,7 +31,7 @@ export function ArticleCard({
                 <div className="relative h-52 sm:h-56 md:h-64 xl:h-72 rounded-lg overflow-hidden border border-gray-800 group-hover:border-purple-500/50 transition-colors">
                     <Image
                         src={imageUrl}
-                        alt={`${title} thumbnail`}
+                        alt={title}
                         fill
                         className="object-cover"
                         sizes="(max-width: 640px) 100vw, (max-width: 1280px) 50vw, 33vw"


### PR DESCRIPTION
- add descriptive alt text to article cards and topic listings
- use post image alt text or titles in blog pages and hero banner
- mark optional body images as decorative when no description is provided

